### PR TITLE
Fix Request.php fatal error

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -122,7 +122,7 @@ class Request
         $info = parse_url($uri);
         $this->path = isset($info['path']) ? $info['path'] : '/'; // for parse_url('?') path will not be set
         if (!empty($info['host'])) {
-            $this->headers->set('Host', $info['host']);
+            $this->headers()->set('Host', $info['host']);
         }
         if (!empty($info['query'])) {
             parse_str($info['query'], $arr);


### PR DESCRIPTION
Fix fatal error in \Vda\Htp\Request class setUri method when provided uri has host or begins with double slash.
